### PR TITLE
Fix: Handle failure of person form submission - 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ group :test do
   gem "rspec-its"
   gem "shoulda"
   gem "simplecov", require: false
+  gem "rails-controller-testing"
 end
 
 # Use Redis for Action Cable

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,10 @@ GEM
       activesupport (= 7.0.1)
       bundler (>= 1.15.0)
       railties (= 7.0.1)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -282,6 +286,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 5.0)
   rails (~> 7.0.1)
+  rails-controller-testing
   redis (~> 4.0)
   rspec-its
   rspec-rails

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -9,17 +9,21 @@ class PeopleController < ApplicationController
   end
 
   def create
-    if Person.create(person_attributes)
+    @person = Person.new(person_attributes)
+    if @person.save
       redirect_to people_path, notice: 'Successfully created entry'
     else
-      render :create, alert: 'Unsuccessfully created entry'
+      respond_to do |format|
+        format.turbo_stream { render turbo_stream: turbo_stream.replace(@person, partial: 'people/form', locals: { person: @person }) }
+        format.html { render :new }
+      end
     end
-  end
+  end 
 
   private
 
   def person_attributes
-    params.require(:person).permit(:name, :email, :phone)
+    params.require(:person).permit(:name, :email, :phone_number)
   end
 
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -12,6 +12,10 @@
 #
 
 class Person < ApplicationRecord
+
+  validates :name, :phone_number, :email, presence: true
+  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :phone_number, format: { with: /\A\+?\d+\z/ }
   
   belongs_to :company, optional: true
 end

--- a/app/views/people/_form.html.slim
+++ b/app/views/people/_form.html.slim
@@ -1,0 +1,17 @@
+= form_for person, class: 'row' do |f|
+  - if person.errors.any?
+    .col-12
+      .alert.alert-danger
+        - person.errors.full_messages.each do |message|
+          li = message
+  .col-auto
+    = f.label :name, class: 'form-label'
+    = f.text_field :name, class: 'form-control'
+  .col-auto
+    = f.label :phone_number, class: 'form-label'
+    = f.text_field :phone_number, class: 'form-control'
+  .col-auto
+    = f.label :email, class: 'form-label'
+    = f.text_field :email, class: 'form-control'
+  .col-auto.mt-4
+    = f.submit class: 'btn btn-primary'

--- a/app/views/people/new.html.slim
+++ b/app/views/people/new.html.slim
@@ -1,14 +1,3 @@
 h2 Creating an entry
 
-= form_for @person, class: 'row' do |f|
-  .col-auto
-    = f.label :name, class: 'form-label'
-    = f.text_field :name, class: 'form-control'
-  .col-auto
-    = f.label :phone_number, class: 'form-label'
-    = f.text_field :phone_number, class: 'form-control'
-  .col-auto
-    = f.label :email, class: 'form-label'
-    = f.text_field :email, class: 'form-control'
-  .col-auto.mt-4
-    = f.submit class: 'btn btn-primary'
+= render 'form', person: @person

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -16,11 +16,12 @@ RSpec.describe PeopleController, type: :controller do
 
   describe 'POST create' do
     it 'Creates a record' do
-      expect{ post :create, params: { person: { name: 'foo', phone_number: '123', email: 'foo' } } }.to change{ Person.count }.by(1)
+      expect{ post :create, params: { person: { name: 'foo', phone_number: '123', email: 'foo@bar.com' } } }.to change{ Person.count }.by(1)
     end
 
-    it 'has status found' do
-      expect(post :create, params: { person: { name: 'foo', phone_number: '123', email: 'foo' } }).to have_http_status(:found)
+    it 'does not create a record when email is invalid' do
+      post :create, params: { person: { name: 'foo', phone_number: '123', email: 'invalid_email' } }
+      expect(assigns(:person).errors[:email]).to include("is invalid")
     end
   end
 end

--- a/spec/features/people/index_spec.rb
+++ b/spec/features/people/index_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe 'Listing people', type: :feature do
   before do 
     Person.create(
       name: 'Foo Bar',
-      phone_number: 'Biz',
-      email: 'Baz'
+      phone_number: '123123',
+      email: 'Baz@zoo.com'
     )
   end
 


### PR DESCRIPTION
**As a front-end user, when creating a new Person entry, when the new entry is unable to be saved, I will see a message with the error, and it will keep the values in the fields I have already filled out.**

- Add Model level validation.
- Make partial `people/_form.html.erb` to reuse it.
- Handle form failure with TURBO_STREAM in rails 7.
- Add error on the `people/_form.html.erb` to display end user.