### PR TITLE
API support added

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,3 +41,6 @@ end
 
 # Use Redis for Action Cable
 gem "redis", "~> 4.0"
+
+# Use for pagination
+gem 'kaminari'

--- a/app/controllers/api/v1/people_controller.rb
+++ b/app/controllers/api/v1/people_controller.rb
@@ -1,0 +1,11 @@
+class Api::V1::PeopleController < ApplicationController
+    def index
+        @people = Person.all
+
+        @people = @people.where(email: params[:email]) if params[:email].present?
+        @people = @people.page(params[:page]).per(params[:per_page])
+        
+        # render json: @people
+        render 'api/v1/people/index' , formats: [:json]
+    end
+end

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -1,0 +1,33 @@
+class CompaniesController < ApplicationController
+    skip_before_action :verify_authenticity_token, only: [:create]
+    http_basic_authenticate_with name: "username", password: "password", only: [:create]
+
+    def index
+      @companies = Company.all
+
+      if params[:name].present?
+        @companies = @companies.where("LOWER(name) LIKE ?", "%#{params[:name].downcase}%")
+      end
+
+      @companies = @companies.page(params[:page]).per(params[:per_page])
+
+      respond_to do |format|
+        format.html
+        format.json { render :index }
+      end
+    end
+
+    def create
+        companies = companies_params[:companies].map do |company_params|
+            Company.create(company_params)
+        end
+
+        render json: companies, status: :created
+    end
+    
+    private
+
+    def companies_params
+        params.permit(companies: [:name])
+    end
+end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -19,7 +19,7 @@ class PeopleController < ApplicationController
   private
 
   def person_attributes
-    params.require(:person).permit(:name, :email, :phone)
+    params.require(:person).permit(:name, :email, :phone_number)
   end
 
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -9,5 +9,9 @@
 #
 
 class Company < ApplicationRecord
+  paginates_per 10
+
   has_many :people
+
+  validates :name, presence: true, length: { maximum: 50 }
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -12,6 +12,7 @@
 #
 
 class Person < ApplicationRecord
-  
+  paginates_per 10
+
   belongs_to :company, optional: true
 end

--- a/app/views/api/v1/people/index.json.jbuilder
+++ b/app/views/api/v1/people/index.json.jbuilder
@@ -1,0 +1,8 @@
+json.people @people do |person|
+    json.extract! person, :id , :name, :email, :phone_number
+end
+
+json.page @people.current_page
+json.per_page @people.limit_value
+json.total_pages @people.total_pages
+json.total_count @people.total_count

--- a/app/views/companies/index.json.jbuilder
+++ b/app/views/companies/index.json.jbuilder
@@ -1,0 +1,8 @@
+json.people @companies do |company|
+    json.extract! company, :id, :name
+end
+
+json.page @companies.current_page
+json.per_page @companies.limit_value
+json.total_pages @companies.total_pages
+json.total_count @companies.total_count

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,14 @@ Rails.application.routes.draw do
 
   resources :people, only: [:index, :new, :create]
   root to: 'people#index'
+
+  namespace :api do
+    namespace :v1 do
+      resources :people
+      # get 'people', to: '/people#index', defaults: { format: 'json' }
+      get 'companies', to: '/companies#index', defaults: { format: 'json' }
+      post 'companies', to: '/companies#create', defaults: { format: 'json' }
+      # resources :companies, only: [:index]
+    end
+  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,20 +10,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_17_214728) do
-
+ActiveRecord::Schema[7.0].define(version: 2024_06_19_072011) do
   create_table "companies", force: :cascade do |t|
     t.string "name"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "companies_people", id: false, force: :cascade do |t|
+    t.integer "company_id", null: false
+    t.integer "person_id", null: false
+    t.index ["company_id", "person_id"], name: "index_companies_people_on_company_id_and_person_id"
+    t.index ["person_id", "company_id"], name: "index_companies_people_on_person_id_and_company_id"
   end
 
   create_table "people", force: :cascade do |t|
     t.string "name", null: false
     t.string "phone_number", null: false
     t.string "email", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "company_id"
     t.index ["company_id"], name: "index_people_on_company_id"
   end

--- a/spec/controllers/api/v1/people_controller_spec.rb
+++ b/spec/controllers/api/v1/people_controller_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::PeopleController, type: :controller do
+  describe "GET #index json" do
+    before do
+      create_list(:person, 20)
+    end
+
+    context "when format is json" do
+      it "returns a list of people" do
+        get :index, format: :json
+        expect(response).to be_successful
+        puts "Response Body: #{response.inspect}" # Add this line
+        puts "vosy: #{response.body}" # Add this line
+        if response.status == 200
+            json = JSON.parse(response.body)
+            expect(json['people'].length).to eq(10) # Example: Adjust based on your pagination or data
+            expect(json).to have_key('page')
+            expect(json).to have_key('per_page')
+            expect(json).to have_key('total_pages')
+            expect(json).to have_key('total_count')
+        end
+      end
+
+      it "filters people by email" do
+        create(:person, email: "specific.email@example.com")
+        get :index, params: { email: "specific.email@example.com" }, format: :json
+        puts "Response Body: #{response.body}" # Add this line
+        expect(response).to be_successful
+        json = JSON.parse(response.body)
+        expect(json['people'].length).to eq(1)
+        expect(json['people'][0]['email']).to eq("specific.email@example.com")
+      end
+    end
+  end
+end

--- a/spec/factories/people.rb
+++ b/spec/factories/people.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+    factory :person do
+      name { Faker::Name.name }
+      email { Faker::Internet.email }
+      phone_number { Faker::PhoneNumber.phone_number }
+    end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,6 +2,8 @@ require 'simplecov'
 SimpleCov.start
 
 require 'spec_helper'
+require 'faker'
+
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
@@ -63,6 +65,7 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include FactoryBot::Syntax::Methods
 end
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|


### PR DESCRIPTION
API Endpoints
Create an API endpoint that exposes People to the public with filtering based on email, and pagination. Example GET request: { email: 'foo@bar.baz', page: 1, per_page: 10 }

Create an API endpoint that exposes Companies to the public with filtering based on case insensitive partial matches to company name with pagination. Example GET request: { name: 'digital', page: 1, per_page: 10 }

Create an API endpoint that exposes Company creation via JSON with basic authentication allowing for the creation of multiple companies. It should return a response with company objects including their newly created IDs Example POST request: { companies: [{ name: 'Foo Bar, Inc' }, ...] }

