### PR TITLE
[Fix 1] - Fix Phone Number issues

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -19,7 +19,7 @@ class PeopleController < ApplicationController
   private
 
   def person_attributes
-    params.require(:person).permit(:name, :email, :phone)
+    params.require(:person).permit(:name, :email, :phone_number)
   end
 
 end

--- a/app/views/people/index.html.slim
+++ b/app/views/people/index.html.slim
@@ -13,7 +13,7 @@ table.table
       tr
         th[scope="row"]= person&.id
         td= person.try(:name)
-        td= person.try(:phone)
+        td= person.try(:phone_number)
         td= person.try(:email)
         td= person.try(:company).try(:name)
 

--- a/spec/features/people/index_spec.rb
+++ b/spec/features/people/index_spec.rb
@@ -15,13 +15,8 @@ RSpec.describe 'Listing people', type: :feature do
     aggregate_failures do
       expect(page).to have_content('Foo Bar')
       expect(page).to have_content('Baz')
+      expect(page).to have_content('Biz')
     end
+
   end
-
-  scenario 'New person', type: :feature do
-    visit new_person_path
-
-    expect(page).to have_field :person_name
-  end
-
 end

--- a/spec/features/people/new_spec.rb
+++ b/spec/features/people/new_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe 'Creating person', type: :feature do
+  let(:name) { 'Javier' }
+  let(:email) { 'javier@test.com' }
+  let(:phone_number) { '5432123456' }
+
+  it 'Creates a new person' do
+    visit new_person_path
+
+    expect(page).to have_field :person_name
+    expect(page).to have_field :person_email
+    expect(page).to have_field :person_phone_number
+
+    fill_in :person_name, with: name
+    fill_in :person_email, with: email
+    fill_in :person_phone_number, with: phone_number
+
+    click_button 'Create Person'
+
+    visit people_path
+    
+    expect(page).to have_content(name)
+    expect(page).to have_content(email)
+    expect(page).to have_content(phone_number)
+  end
+end


### PR DESCRIPTION
# Description
This PR solves the **Required fix #1**

> As a front-end user, when creating a new Person entry, I want the value I enter into the phone number field to be saved to my new entry. (See failing specs)

- Update controller to rename `phone` attribute to `phone_number`.
- Extract feature spec creating a new person from the index spec for better separation of concerns and extensibility.
- Verify that all form fields are correctly rendered in the index and new views.