### PR TITLE
Allow phone number to be saved

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -19,8 +19,7 @@ class PeopleController < ApplicationController
   private
 
   def person_attributes
-    params.require(:person).permit(:name, :email, :phone)
+    params.require(:person).permit(:name, :email, :phone_number)
   end
 
 end
-

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -12,6 +12,8 @@
 #
 
 class Person < ApplicationRecord
-  
+
   belongs_to :company, optional: true
+
+  validates :name, :phone_number, :email, presence: true
 end


### PR DESCRIPTION
Fix permitted params for creating a user with a phone number.

Since the fields are `NOT NULL` in the database, a presence validation was also added.

Fixes the *required fix* defined on the README