### PR TITLE
[Issue User Stories 4] - Show create person error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :development, :test do
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
   gem "rspec-rails"
   gem "pry-rails"
+  gem "rails-controller-testing"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,6 +171,10 @@ GEM
       activesupport (= 7.0.8.6)
       bundler (>= 1.15.0)
       railties (= 7.0.8.6)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
@@ -293,6 +297,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 5.0)
   rails (~> 7.0.1)
+  rails-controller-testing
   redis (~> 4.0)
   rspec-its
   rspec-rails

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -9,17 +9,18 @@ class PeopleController < ApplicationController
   end
 
   def create
-    if Person.create(person_attributes)
+    @person = Person.new(person_attributes)
+    if @person.save
       redirect_to people_path, notice: 'Successfully created entry'
     else
-      render :create, alert: 'Unsuccessfully created entry'
+      render :new, status: :unprocessable_entity
     end
   end
 
   private
 
   def person_attributes
-    params.require(:person).permit(:name, :email, :phone)
+    params.require(:person).permit(:name, :email, :phone_number)
   end
 
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -14,4 +14,8 @@
 class Person < ApplicationRecord
   
   belongs_to :company, optional: true
+
+  validates :name, :email, :phone_number, presence: true
+  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :email, uniqueness: { scope: :company_id }, if: -> { company_id.present? }
 end

--- a/app/views/people/new.html.slim
+++ b/app/views/people/new.html.slim
@@ -1,6 +1,11 @@
 h2 Creating an entry
 
 = form_for @person, class: 'row' do |f|
+  - if @person.errors.any?
+    .alert.alert-danger.d-block
+      ul
+        - @person.errors.full_messages.each do |message|
+          li=message
   .col-auto
     = f.label :name, class: 'form-label'
     = f.text_field :name, class: 'form-control'

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -15,12 +15,31 @@ RSpec.describe PeopleController, type: :controller do
   end
 
   describe 'POST create' do
-    it 'Creates a record' do
-      expect{ post :create, params: { person: { name: 'foo', phone_number: '123', email: 'foo' } } }.to change{ Person.count }.by(1)
+    context 'when the record is valid' do
+      let(:params) { { person: { name: 'foo', phone_number: '123', email: 'foo@email.com' } } }
+
+      it 'Creates a record' do
+        expect{ post :create, params: params }.to change{ Person.count }.by(1)
+      end
+
+      it 'has status found' do
+        post :create, params: params
+        expect(response).to have_http_status(:found)
+      end
     end
 
-    it 'has status found' do
-      expect(post :create, params: { person: { name: 'foo', phone_number: '123', email: 'foo' } }).to have_http_status(:found)
+    context 'when the record is invalid' do
+      let(:params) { { person: { name: 'foo', phone_number: '123', email: 'foo' } } }
+
+      it 'does not create a record' do
+        expect{ post :create, params: params }.to change{ Person.count }.by(0)
+      end
+
+      it 'has status unprocessable_entity' do
+        post :create, params: params
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(assigns(:person).errors[:email]).to include("is invalid")
+      end
     end
   end
 end

--- a/spec/features/people/index_spec.rb
+++ b/spec/features/people/index_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Listing people', type: :feature do
     Person.create(
       name: 'Foo Bar',
       phone_number: 'Biz',
-      email: 'Baz'
+      email: 'Baz@email.com'
     )
   end
 
@@ -14,7 +14,7 @@ RSpec.describe 'Listing people', type: :feature do
 
     aggregate_failures do
       expect(page).to have_content('Foo Bar')
-      expect(page).to have_content('Baz')
+      expect(page).to have_content('Baz@email.com')
     end
   end
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -15,4 +15,47 @@ require 'rails_helper'
 
 RSpec.describe Person, type: :model do
   it { is_expected.to belong_to(:company).optional }
+
+  it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to validate_presence_of(:email) }
+  it { is_expected.to validate_presence_of(:phone_number) }
+
+  describe 'validations' do
+    let(:email) { 'foo@bar.com' }
+    let(:name) { 'Foo Bar' }
+    let(:phone_number) { '1234567890' }
+
+    let(:company1) { Company.create(name: 'Company 1') }
+    let(:company2) { Company.create(name: 'Company 2') }
+    let!(:person) { Person.create(company: company1, email: email, name: name, phone_number: phone_number) }
+    let!(:person2) { Person.new(company: company2, email: email, name: name, phone_number: phone_number) }
+
+    context 'with valid attributes' do
+      it 'is valid' do
+        expect(person).to be_valid
+      end
+    end
+
+    context 'when the email is invalid' do
+      let(:email) { 'invalid' }
+
+      it 'is invalid' do
+        expect(person).to be_invalid
+      end
+    end
+
+    context 'when the email is unique' do
+      it 'is valid' do
+        expect(person2).to be_valid
+      end
+    end
+
+    context 'when the email is not unique for the same company' do
+      let(:company2) { company1 }
+
+      it 'is invalid' do
+        expect(person2).to_not be_valid
+      end
+    end
+  end
 end


### PR DESCRIPTION
### This PR solves the Issue User Stories 4.

>
As a front-end user, when creating a new Person entry, when the new entry is unable to be saved, I will see a message with the error, and it will keep the values in the fields I have already filled out.

### Changes
- Added `rails-controller-testing` gem for improved controller testing.
- Updated `create` action in `PeopleController` to use `@person.save` and render errors appropriately.
- Modified `person_attributes` method to permit `:phone_number` instead of `:phone`. (fix #1)
- Added presence and format validations for `name`, `email`, and `phone_number` in the `Person` model.
- Updated views to display error messages for invalid entries.
- Enhanced controller and model specs to cover new validations and error handling.

### Demo
https://www.loom.com/share/e652fcb763fa495ea42a913474d0ce83?sid=ae42c23a-b23a-421d-852f-4dbe4a3e5073 