### PR TITLE
[Feature User Stories 5] - Company CRU[D]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ group :test do
   gem "rspec-its"
   gem "shoulda"
   gem "simplecov", require: false
+  gem 'rails-controller-testing'
 end
 
 # Use Redis for Action Cable

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,6 +171,10 @@ GEM
       activesupport (= 7.0.8.6)
       bundler (>= 1.15.0)
       railties (= 7.0.8.6)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
@@ -293,6 +297,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 5.0)
   rails (~> 7.0.1)
+  rails-controller-testing
   redis (~> 4.0)
   rspec-its
   rspec-rails

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -1,0 +1,50 @@
+class CompaniesController < ApplicationController
+  before_action :set_company, only: [:show, :edit, :update, :destroy]
+
+  def index
+    @companies = Company.all
+  end
+
+  def show
+  end
+
+  def new
+    @company = Company.new
+  end
+
+  def edit
+  end
+
+  def create
+    @company = Company.new(company_params)
+
+    if @company.save
+      redirect_to companies_path, notice: 'Company was successfully created.'
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @company.update(company_params)
+      redirect_to companies_path, notice: 'Company was successfully updated.'
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @company.destroy
+    redirect_to companies_path, notice: 'Company was successfully deleted.'
+  end
+
+  private
+
+  def set_company
+    @company = Company.find(params[:id])
+  end
+
+  def company_params
+    params.require(:company).permit(:name)
+  end
+end 

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -1,5 +1,5 @@
 class CompaniesController < ApplicationController
-  before_action :set_company, only: [:show, :edit, :update, :destroy]
+  before_action :set_company, only: [:show, :edit, :update]
 
   def index
     @companies = Company.all
@@ -31,11 +31,6 @@ class CompaniesController < ApplicationController
     else
       render :edit, status: :unprocessable_entity
     end
-  end
-
-  def destroy
-    @company.destroy
-    redirect_to companies_path, notice: 'Company was successfully deleted.'
   end
 
   private

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -19,7 +19,7 @@ class PeopleController < ApplicationController
   private
 
   def person_attributes
-    params.require(:person).permit(:name, :email, :phone)
+    params.require(:person).permit(:name, :email, :phone_number)
   end
 
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -9,5 +9,7 @@
 #
 
 class Company < ApplicationRecord
-  has_many :people
+  has_many :people, dependent: :nullify
+  
+  validates :name, presence: true
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -9,7 +9,7 @@
 #
 
 class Company < ApplicationRecord
-  has_many :people, dependent: :nullify
+  has_many :people, dependent: :restrict_with_error
   
   validates :name, presence: true
 end

--- a/app/views/companies/_form.html.slim
+++ b/app/views/companies/_form.html.slim
@@ -1,0 +1,13 @@
+= form_for @company do |f|
+  - if @company.errors.any?
+    .alert.alert-danger
+      ul
+        - @company.errors.full_messages.each do |message|
+          li= message
+  .mb-3
+    = f.label :name, class: 'form-label'
+    = f.text_field :name, class: 'form-control'
+
+  .actions
+    = f.submit class: 'btn btn-primary'
+    = link_to 'Back', companies_path, class: 'btn btn-link' 

--- a/app/views/companies/edit.html.slim
+++ b/app/views/companies/edit.html.slim
@@ -1,0 +1,3 @@
+h2 Edit Company
+
+= render 'form' 

--- a/app/views/companies/index.html.slim
+++ b/app/views/companies/index.html.slim
@@ -15,7 +15,3 @@ table.table
         td
           .btn-group
             = link_to 'Edit', edit_company_path(company), class: 'btn btn-sm btn-outline-primary'
-            = link_to 'Delete', company_path(company), 
-              method: :delete, 
-              class: 'btn btn-sm btn-outline-danger', 
-              data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } 

--- a/app/views/companies/index.html.slim
+++ b/app/views/companies/index.html.slim
@@ -1,0 +1,21 @@
+h2 Companies
+
+.mb-3
+  = link_to 'New Company', new_company_path, class: 'btn btn-primary'
+
+table.table
+  thead
+    tr
+      th[scope="col"] Name
+      th[scope="col"] Actions
+  tbody
+    - @companies.each do |company|
+      tr
+        td= company.name
+        td
+          .btn-group
+            = link_to 'Edit', edit_company_path(company), class: 'btn btn-sm btn-outline-primary'
+            = link_to 'Delete', company_path(company), 
+              method: :delete, 
+              class: 'btn btn-sm btn-outline-danger', 
+              data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } 

--- a/app/views/companies/new.html.slim
+++ b/app/views/companies/new.html.slim
@@ -1,0 +1,3 @@
+h2 New Company
+
+= render 'form' 

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -18,7 +18,11 @@ html[lang="en"]
             li.nav-item
               a.nav-link[aria-current="page" href="/"]All
             li.nav-item
-              = link_to('Create', new_person_path, class: 'nav-link')
+              = link_to 'People', people_path, class: 'nav-link'
+            li.nav-item
+              = link_to 'Companies', companies_path, class: 'nav-link'
+            li.nav-item
+              = link_to('Create Person', new_person_path, class: 'nav-link')
           form.d-flex
             input.form-control.me-2[type="search" placeholder="Search" aria-label="Search"]
             button.btn.btn-outline-success[type="submit"] Search

--- a/app/views/people/index.html.slim
+++ b/app/views/people/index.html.slim
@@ -13,7 +13,7 @@ table.table
       tr
         th[scope="row"]= person&.id
         td= person.try(:name)
-        td= person.try(:phone)
+        td= person.try(:phone_number)
         td= person.try(:email)
         td= person.try(:company).try(:name)
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-
+  resources :companies
   resources :people, only: [:index, :new, :create]
   root to: 'people#index'
 end

--- a/spec/controllers/companies_controller_spec.rb
+++ b/spec/controllers/companies_controller_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+
+RSpec.describe CompaniesController, type: :controller do
+  let(:valid_attributes) { { name: 'Test Company' } }
+  let(:invalid_attributes) { { name: '' } }
+
+  describe 'GET index' do
+    it 'returns http success' do
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe 'GET new' do
+    it 'returns http success' do
+      get :new
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe 'POST create' do
+    context 'with valid parameters' do
+      it 'creates a new Company' do
+        expect {
+          post :create, params: { company: valid_attributes }
+        }.to change(Company, :count).by(1)
+      end
+
+      it 'redirects to the companies list' do
+        post :create, params: { company: valid_attributes }
+        expect(response).to redirect_to(companies_path)
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'does not create a new Company' do
+        expect {
+          post :create, params: { company: invalid_attributes }
+        }.to change(Company, :count).by(0)
+      end
+
+      it 'renders new template with unprocessable_entity status' do
+        post :create, params: { company: invalid_attributes }
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to render_template(:new)
+      end
+    end
+  end
+
+  describe 'PUT update' do
+    let(:company) { Company.create!(valid_attributes) }
+
+    context 'with valid parameters' do
+      let(:new_attributes) { { name: 'Updated Company' } }
+
+      it 'updates the requested company' do
+        put :update, params: { id: company.to_param, company: new_attributes }
+        company.reload
+        expect(company.name).to eq('Updated Company')
+      end
+
+      it 'redirects to the companies list' do
+        put :update, params: { id: company.to_param, company: new_attributes }
+        expect(response).to redirect_to(companies_path)
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'renders edit template with unprocessable_entity status' do
+        put :update, params: { id: company.to_param, company: invalid_attributes }
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+
+  describe 'DELETE destroy' do
+    let!(:company) { Company.create!(valid_attributes) }
+
+    it 'destroys the requested company' do
+      expect {
+        delete :destroy, params: { id: company.to_param }
+      }.to change(Company, :count).by(-1)
+    end
+
+    it 'redirects to the companies list' do
+      delete :destroy, params: { id: company.to_param }
+      expect(response).to redirect_to(companies_path)
+    end
+  end
+end 

--- a/spec/controllers/companies_controller_spec.rb
+++ b/spec/controllers/companies_controller_spec.rb
@@ -73,19 +73,4 @@ RSpec.describe CompaniesController, type: :controller do
       end
     end
   end
-
-  describe 'DELETE destroy' do
-    let!(:company) { Company.create!(valid_attributes) }
-
-    it 'destroys the requested company' do
-      expect {
-        delete :destroy, params: { id: company.to_param }
-      }.to change(Company, :count).by(-1)
-    end
-
-    it 'redirects to the companies list' do
-      delete :destroy, params: { id: company.to_param }
-      expect(response).to redirect_to(companies_path)
-    end
-  end
 end 


### PR DESCRIPTION
### This PR solves the Feature User Stories 5.

>
As a front-end user, I want to be able to list companies, create a new company, and edit companies

### Changes
- Added `rails-controller-testing` gem for improved controller testing.
- Created the CRUD for companies (see notes)

### Demo
With delete
https://www.loom.com/share/2f676b1a909c4508b983170868a7630e?sid=36f247c9-d632-4079-8a59-7948f9f0de05

Without delete
https://www.loom.com/share/4781d8acf5c24d979cd49d470f970c67?sid=0b50c074-1cd7-41a6-9bfc-a243ded8f28c

### Notes
- The first commit is fixing the phone attribute (from :phone to :phone_number) in the controller and view to make the tests pass
- The second commit, adds all the CRUD logic, including delete the company
- The third commit, removes the logic to remove the company
- _**In a real case scenario, I'll ask if I should add the remove button before starting the development**_ 
